### PR TITLE
fix: support freeform date phrases in parser; add tests; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ todo add "Call doctor @phone ~high energy:low est:15m (waiting: insurance approv
 
 # Quick pinned reminder
 todo add "Submit expense report due end of week [P]"
+
+# Freeform date phrases (no explicit 'due' needed)
+todo add "Pay rent by Monday"
+todo add "Pick up order on 9/21"
+todo add "Write recap for tomorrow"
 ```
 
 ### 🎨 Natural Language Syntax Guide

--- a/tests/test_parser_freeform.py
+++ b/tests/test_parser_freeform.py
@@ -1,0 +1,39 @@
+"""Freeform date parsing tests for NaturalLanguageParser."""
+
+from datetime import datetime, timedelta
+
+from src.todo_cli.parser import NaturalLanguageParser
+from src.todo_cli.config import ConfigModel
+
+
+class TestFreeformDateParsing:
+    def setup_method(self):
+        self.config = ConfigModel()
+        self.parser = NaturalLanguageParser(self.config)
+
+    def test_freeform_for_tomorrow(self):
+        parsed, errors = self.parser.parse("Test todo for tomorrow")
+        assert len(errors) == 0
+        assert parsed.text == "Test todo"
+        assert parsed.due_date is not None
+        expected_date = (datetime.now() + timedelta(days=1)).date()
+        assert parsed.due_date.date() == expected_date
+
+    def test_freeform_by_monday(self):
+        parsed, errors = self.parser.parse("Finish report by Monday")
+        assert len(errors) == 0
+        assert parsed.text == "Finish report"
+        assert parsed.due_date is not None  # exact weekday depends on current date
+
+    def test_freeform_on_numeric_date(self):
+        parsed, errors = self.parser.parse("Call mom on 12/25")
+        assert len(errors) == 0
+        assert parsed.text == "Call mom"
+        assert parsed.due_date is not None
+
+    def test_word_boundary_for_at(self):
+        # Ensure 'at' inside words (e.g., 'Latest') does not trigger scheduled matching
+        parsed, errors = self.parser.parse("Latest release notes")
+        assert len(errors) == 0
+        assert parsed.text == "Latest release notes"
+        assert parsed.scheduled_date is None


### PR DESCRIPTION
key fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Parse freeform date phrases in task text (e.g., “by Monday”, “on 9/21”, “for tomorrow”), automatically setting due dates while keeping task titles clean.

- Bug Fixes
  - Reduced false scheduling when “at” appears inside words.
  - Improved cleanup of dangling prepositions (for/by/on/at) at the end of text.
  - Clearer handling when input contains only metadata, avoiding confusing errors.

- Documentation
  - Added Quick Start examples showcasing freeform date phrases:
    - Pay rent by Monday
    - Pick up order on 9/21
    - Write recap for tomorrow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->