### PR TITLE
Harden desktop notifications, exports, and CORS security

### DIFF
--- a/src/todo_cli/cli/tasks.py
+++ b/src/todo_cli/cli/tasks.py
@@ -1,5 +1,6 @@
 """New clean command-line interface for Todo CLI."""
 
+import os
 import sys
 from typing import Optional
 from datetime import datetime, timedelta
@@ -1587,7 +1588,7 @@ def export(format_type, output, project, include_completed, exclude_completed, i
                 if sys.platform == "darwin":  # macOS
                     subprocess.run(["open", output])
                 elif sys.platform == "win32":  # Windows
-                    subprocess.run(["start", output], shell=True)
+                    os.startfile(output)
                 else:  # Linux and others
                     subprocess.run(["xdg-open", output])
                 get_console().print(f"[success]🚀 Opened {output}[/success]")

--- a/src/todo_cli/services/notifications.py
+++ b/src/todo_cli/services/notifications.py
@@ -208,10 +208,19 @@ class DesktopNotificationDelivery(NotificationDelivery):
         """Send macOS notification using osascript"""
         try:
             # Use subprocess arguments directly to avoid shell escaping issues
+            title = notification.title or ""
+            message = notification.message or ""
             cmd = [
-                "osascript", 
-                "-e", 
-                f'display notification "{notification.message}" with title "{notification.title}" sound name "Glass"'
+                "osascript",
+                "-e",
+                "on run argv",
+                "-e",
+                "display notification (item 2 of argv) with title (item 1 of argv) sound name (item 3 of argv)",
+                "-e",
+                "end run",
+                str(title),
+                str(message),
+                "Glass",
             ]
             
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)

--- a/src/todo_cli/services/notifications.py
+++ b/src/todo_cli/services/notifications.py
@@ -215,7 +215,7 @@ class DesktopNotificationDelivery(NotificationDelivery):
                 "-e",
                 "on run argv",
                 "-e",
-                "display notification (item 2 of argv) with title (item 1 of argv) sound name (item 3 of argv)",
+                "display notification (item 2 of argv) with title (item 1 of argv) with sound name (item 3 of argv)",
                 "-e",
                 "end run",
                 str(title),

--- a/src/todo_cli/web/server.py
+++ b/src/todo_cli/web/server.py
@@ -118,16 +118,16 @@ app = FastAPI(
 )
 
 # Add CORS middleware for development and PWA
+# Restrict CORS origins to trusted development hosts and avoid credentialed requests
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        "*",  # Allow all origins for development
         "http://localhost:3000",
         "http://127.0.0.1:3000",
         "http://localhost:8000",
-        "http://127.0.0.1:8000"
+        "http://127.0.0.1:8000",
     ],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- Safely invoke macOS desktop notifications by passing title and message as AppleScript arguments
- Open exported files on Windows without invoking the shell to avoid command injection
- Restrict CORS origins to trusted development hosts and disable credentialed requests

## Testing
- pytest *(fails: missing optional test dependencies `yaml` and `fastapi`)*

------
https://chatgpt.com/codex/tasks/task_e_6906838ee62c833287ceac02b56b665c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-opening behavior on Windows so exported files open reliably.
  * Improved macOS notification delivery and sanitization for empty titles/messages.

* **Security**
  * Restricted CORS to trusted local development origins and disabled credentialed cross-origin requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->