### PR TITLE
Improve PWA backup handling and board display

### DIFF
--- a/src/todo_cli/web/server.py
+++ b/src/todo_cli/web/server.py
@@ -143,6 +143,116 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 # Initialize templates
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
+# Backup configuration
+BACKUP_DIR = Path.home() / ".todo" / "backups"
+
+
+def ensure_backup_dir() -> Path:
+    """Ensure backup directory exists and return its path."""
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    return BACKUP_DIR
+
+
+def sanitize_backup_filename(filename: str) -> str:
+    """Validate backup filenames to prevent path traversal."""
+    normalized = Path(filename).name
+    if normalized != filename or ".." in Path(filename).parts:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Invalid backup filename")
+    if not normalized.endswith(".json"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Backups must be JSON files")
+    return normalized
+
+
+def build_backup_payload(storage: Storage) -> Dict[str, Any]:
+    """Create a snapshot of all projects and tasks for backup."""
+    config = get_config()
+    projects = storage.list_projects() or [config.default_project]
+
+    backup_data: Dict[str, Any] = {
+        "projects": {},
+        "config": {
+            "default_project": config.default_project,
+        },
+        "metadata": {
+            "created_at": datetime.utcnow().isoformat() + "Z",
+            "version": "1.0"
+        },
+        "backup_metadata": {
+            "version": "1.0",
+            "backup_type": "manual"
+        }
+    }
+
+    for project_name in projects:
+        try:
+            project, todos = storage.load_project(project_name)
+            if project or todos:
+                backup_data["projects"][project_name] = {
+                    "project": project.to_dict() if project else {"name": project_name},
+                    "todos": [todo.to_dict() for todo in todos] if todos else []
+                }
+        except Exception:
+            continue
+
+    return backup_data
+
+
+def list_backup_files() -> List[BackupResponse]:
+    """List available backups with metadata."""
+    backup_dir = ensure_backup_dir()
+    backups: List[BackupResponse] = []
+
+    for backup_file in sorted(backup_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+        stat = backup_file.stat()
+        created_at = datetime.fromtimestamp(stat.st_mtime).isoformat() + "Z"
+
+        try:
+            with backup_file.open("r") as f:
+                data = json.load(f)
+                meta = data.get("backup_metadata", {})
+                created_at = meta.get("timestamp", created_at)
+        except Exception:
+            pass
+
+        backups.append(BackupResponse(
+            filename=backup_file.name,
+            created_at=created_at,
+            size=stat.st_size,
+        ))
+
+    return backups
+
+
+def restore_backup(storage: Storage, filename: str) -> None:
+    """Restore all projects and todos from a backup file."""
+    safe_name = sanitize_backup_filename(filename)
+    backup_path = ensure_backup_dir() / safe_name
+
+    if not backup_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Backup not found")
+
+    with backup_path.open("r") as f:
+        backup_data = json.load(f)
+
+    projects_data = backup_data.get("projects", {})
+    if not isinstance(projects_data, dict):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid backup format")
+
+    for project_name, payload in projects_data.items():
+        try:
+            project_dict = payload.get("project", {"name": project_name})
+            todos_data = payload.get("todos", [])
+
+            project = Project.from_dict(project_dict)
+            todos = [Todo.from_dict(todo_dict) for todo_dict in todos_data if isinstance(todo_dict, dict)]
+
+            storage.save_project(project, todos)
+        except Exception as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail=f"Failed to restore project {project_name}: {exc}")
+
 # Global dependencies
 def get_todo_storage():
     """Get the todo storage instance."""
@@ -638,29 +748,48 @@ async def get_tags(storage=Depends(get_todo_storage)):
 async def get_backups():
     """Get list of available backups."""
     try:
-        # For now, return empty list
-        # TODO: Implement backup functionality
-        return []
+        return list_backup_files()
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error retrieving backups: {str(e)}")
 
 
-@app.post("/api/backups")
-async def create_backup_api():
+@app.post("/api/backups", response_model=BackupResponse)
+async def create_backup_api(storage=Depends(get_todo_storage)):
     """Create a new backup."""
     try:
-        # TODO: Implement backup functionality
-        return {"message": "Backup functionality not yet implemented", "filename": None}
+        ensure_backup_dir()
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        filename = f"{timestamp}_manual.json"
+        backup_path = BACKUP_DIR / filename
+
+        payload = build_backup_payload(storage)
+        payload["backup_metadata"]["timestamp"] = datetime.utcnow().isoformat() + "Z"
+
+        with backup_path.open("w") as f:
+            json.dump(payload, f, indent=2)
+
+        stat = backup_path.stat()
+        return BackupResponse(
+            filename=filename,
+            created_at=payload["backup_metadata"]["timestamp"],
+            size=stat.st_size,
+        )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error creating backup: {str(e)}")
 
 
 @app.post("/api/backups/{filename}/restore")
-async def restore_backup_api(filename: str):
+async def restore_backup_api(filename: str, storage=Depends(get_todo_storage)):
     """Restore from a backup."""
     try:
-        # TODO: Implement restore functionality
-        return {"message": "Restore functionality not yet implemented"}
+        restore_backup(storage, filename)
+        return {"message": "Restore completed"}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error restoring backup: {str(e)}")
 

--- a/src/todo_cli/web/static/js/app.js
+++ b/src/todo_cli/web/static/js/app.js
@@ -598,11 +598,11 @@ class TodoApp {
     renderBoard(tasks) {
         // Get all board columns with defensive checks
         const pendingColumn = document.getElementById('pending-tasks');
-        const inProgressColumn = document.getElementById('in-progress-tasks');
+        const blockedColumn = document.getElementById('blocked-tasks');
         const completedColumn = document.getElementById('completed-tasks');
 
         // Clear all columns safely
-        const columns = { pendingColumn, inProgressColumn, completedColumn };
+        const columns = { pendingColumn, blockedColumn, completedColumn };
         Object.values(columns).forEach(column => {
             if (column) column.innerHTML = '';
         });
@@ -622,7 +622,7 @@ class TodoApp {
         }
 
         // Track tasks per column for empty state handling
-        const columnCounts = { pending: 0, inProgress: 0, completed: 0 };
+        const columnCounts = { pending: 0, blocked: 0, completed: 0 };
 
         // Distribute tasks to columns with error handling
         validTasks.forEach(task => {
@@ -635,9 +635,9 @@ class TodoApp {
                 if (status === 'completed' && completedColumn) {
                     completedColumn.appendChild(taskElement);
                     columnCounts.completed++;
-                } else if ((status === 'in-progress' || status === 'blocked') && inProgressColumn) {
-                    inProgressColumn.appendChild(taskElement);
-                    columnCounts.inProgress++;
+                } else if (status === 'blocked' && blockedColumn) {
+                    blockedColumn.appendChild(taskElement);
+                    columnCounts.blocked++;
                 } else if (pendingColumn) {
                     pendingColumn.appendChild(taskElement);
                     columnCounts.pending++;
@@ -654,7 +654,7 @@ class TodoApp {
     renderBoardEmptyState() {
         const columns = {
             pendingColumn: document.getElementById('pending-tasks'),
-            inProgressColumn: document.getElementById('in-progress-tasks'),
+            blockedColumn: document.getElementById('blocked-tasks'),
             completedColumn: document.getElementById('completed-tasks')
         };
         
@@ -673,7 +673,7 @@ class TodoApp {
     }
 
     addEmptyColumnStates(columns, columnCounts) {
-        const { pendingColumn, inProgressColumn, completedColumn } = columns;
+        const { pendingColumn, blockedColumn, completedColumn } = columns;
         
         if (pendingColumn && columnCounts.pending === 0) {
             const emptyDiv = document.createElement('div');
@@ -682,11 +682,11 @@ class TodoApp {
             pendingColumn.appendChild(emptyDiv);
         }
         
-        if (inProgressColumn && columnCounts.inProgress === 0) {
+        if (blockedColumn && columnCounts.blocked === 0) {
             const emptyDiv = document.createElement('div');
             emptyDiv.className = 'column-empty-state';
-            emptyDiv.innerHTML = '<p class="empty-message">Tasks in progress will appear here</p>';
-            inProgressColumn.appendChild(emptyDiv);
+            emptyDiv.innerHTML = '<p class="empty-message">Blocked tasks will appear here</p>';
+            blockedColumn.appendChild(emptyDiv);
         }
         
         if (completedColumn && columnCounts.completed === 0) {
@@ -849,13 +849,18 @@ class TodoApp {
         backups.forEach(backup => {
             const backupElement = document.createElement('div');
             backupElement.className = 'backup-item';
+
+            const filename = ui.escapeHtml(String(backup.filename || ''));
+            const createdAt = backup.created_at ? ui.formatDateTime(backup.created_at) : 'Unknown';
+            const sizeKb = backup.size ? (Number(backup.size) / 1024).toFixed(1) : '0.0';
+
             backupElement.innerHTML = `
                 <div class="backup-info">
-                    <strong>${backup.filename}</strong>
-                    <p>Created: ${ui.formatDateTime(backup.created_at)} | Size: ${(backup.size / 1024).toFixed(1)} KB</p>
+                    <strong>${filename}</strong>
+                    <p>Created: ${ui.escapeHtml(createdAt)} | Size: ${ui.escapeHtml(sizeKb)} KB</p>
                 </div>
                 <div class="backup-actions">
-                    <button class="btn btn-sm restore-backup" data-filename="${backup.filename}">Restore</button>
+                    <button class="btn btn-sm restore-backup" data-filename="${filename}">Restore</button>
                 </div>
             `;
 

--- a/src/todo_cli/web/templates/index.html
+++ b/src/todo_cli/web/templates/index.html
@@ -76,9 +76,9 @@
                         <h3>To Do</h3>
                         <div class="board-tasks" id="pending-tasks"></div>
                     </div>
-                    <div class="board-column" data-status="in-progress">
-                        <h3>In Progress</h3>
-                        <div class="board-tasks" id="in-progress-tasks"></div>
+                    <div class="board-column" data-status="blocked">
+                        <h3>Blocked</h3>
+                        <div class="board-tasks" id="blocked-tasks"></div>
                     </div>
                     <div class="board-column" data-status="completed">
                         <h3>Completed</h3>


### PR DESCRIPTION
## Summary
- implement secure backup creation, listing, and restoration endpoints for the PWA API
- align the board view to the existing blocked/completed status model and harden backup rendering against injection

## Testing
- uv run python -m pytest tests/test_api.py -k health --maxfail=1 *(fails: missing itsdangerous dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273110aaa48332b525f5ba6ec1e16a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds secure backup create/list/restore APIs and updates the board UI to use a blocked column with safer backup rendering.
> 
> - **Backend (FastAPI)**:
>   - **Backups**: Add secure backup system with `ensure_backup_dir`, filename sanitization, snapshot builder, listing (`list_backup_files`), and restoration (`restore_backup`).
>   - **API Endpoints**: Implement `GET /api/backups` (lists backups), `POST /api/backups` (creates JSON backup with metadata), and `POST /api/backups/{filename}/restore` (restores); return `BackupResponse` and robust error handling.
> - **Frontend (JS)**:
>   - **Board View**: Replace "in-progress" with "blocked" column; update distribution, empty states, and DOM IDs accordingly.
>   - **Backup UI**: Escape/format filename, timestamp, and size; wire restore action with safe data attributes.
> - **Templates**:
>   - **Board Markup**: Update board columns/IDs to `blocked-tasks` to match new status model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 675374fc9da1aedf875084f1265e22f62d087e7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->