### PR TITLE
Add missing web dependencies and correct weekly analytics window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "jinja2>=3.1.0",
     "bcrypt>=4.1.0",
     "pyjwt>=2.8.0",
+    "itsdangerous>=2.1.2",
+    "python-multipart>=0.0.20",
     "watchdog>=4.0.0",
 ]
 

--- a/src/todo_cli/services/analytics.py
+++ b/src/todo_cli/services/analytics.py
@@ -284,8 +284,11 @@ class ProductivityAnalyzer:
         if timeframe == AnalyticsTimeframe.DAILY:
             return end_date.replace(hour=0, minute=0, second=0, microsecond=0)
         elif timeframe == AnalyticsTimeframe.WEEKLY:
-            days_back = end_date.weekday()
-            return (end_date - timedelta(days=days_back)).replace(hour=0, minute=0, second=0, microsecond=0)
+            # Use a rolling 7-day window to capture tasks from the previous week even if the
+            # current week has just started (e.g., Monday morning). Using a fixed "start of
+            # week" anchor could drop tasks from the past few days and inflate completion
+            # metrics.
+            return (end_date - timedelta(days=7)).replace(hour=0, minute=0, second=0, microsecond=0)
         elif timeframe == AnalyticsTimeframe.MONTHLY:
             return end_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         elif timeframe == AnalyticsTimeframe.QUARTERLY:

--- a/uv.lock
+++ b/uv.lock
@@ -659,6 +659,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1354,6 +1363,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1595,6 +1613,7 @@ dependencies = [
     { name = "fpdf2" },
     { name = "fuzzywuzzy" },
     { name = "httpx" },
+    { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "keyring" },
     { name = "parsedatetime" },
@@ -1604,6 +1623,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "python-frontmatter" },
     { name = "python-levenshtein" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "tabulate" },
@@ -1645,6 +1665,7 @@ requires-dist = [
     { name = "fpdf2", marker = "extra == 'pdf'", specifier = ">=2.8.0" },
     { name = "fuzzywuzzy", specifier = ">=0.18.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "itsdangerous", specifier = ">=2.1.2" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "keyring", specifier = ">=24.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
@@ -1659,6 +1680,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "python-levenshtein", specifier = ">=0.27.1" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "tabulate", specifier = ">=0.9.0" },


### PR DESCRIPTION
## Summary
- add required FastAPI session/form dependencies to the project
- adjust weekly analytics window to use a rolling 7-day period
- update lockfile after dependency additions

## Testing
- uv run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69277c64a2d08332b4780a21bfcd0320)