### PR TITLE
Migrate to Pydantic v2 validators and add FastAPI lifespan hook

### DIFF
--- a/src/todo_cli/sync/app_sync_config.py
+++ b/src/todo_cli/sync/app_sync_config.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 _yaml_spec = importlib.util.find_spec("yaml")
 yaml = importlib.import_module("yaml") if _yaml_spec is not None else None
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -90,13 +90,15 @@ class ProviderSettings(BaseModel):
     rate_limit_requests_per_minute: int = 50
     batch_size: int = 100
     
-    @validator('sync_interval')
+    @field_validator("sync_interval")
+    @classmethod
     def validate_sync_interval(cls, v):
         if v < 60:
             raise ValueError('Sync interval must be at least 60 seconds')
         return v
     
-    @validator('rate_limit_requests_per_minute')
+    @field_validator("rate_limit_requests_per_minute")
+    @classmethod
     def validate_rate_limit(cls, v):
         if v < 1 or v > 1000:
             raise ValueError('Rate limit must be between 1 and 1000 requests per minute')
@@ -130,7 +132,8 @@ class GlobalSyncSettings(BaseModel):
     log_sync_operations: bool = True
     debug_mode: bool = False
     
-    @validator('max_concurrent_syncs')
+    @field_validator("max_concurrent_syncs")
+    @classmethod
     def validate_concurrent_syncs(cls, v):
         if v < 1 or v > 10:
             raise ValueError('Max concurrent syncs must be between 1 and 10')

--- a/src/todo_cli/webapp/app.py
+++ b/src/todo_cli/webapp/app.py
@@ -3,6 +3,7 @@ FastAPI Web Application for Todo CLI
 Terminal-inspired task management web interface
 """
 
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -29,11 +30,19 @@ from todo_cli.webapp.models import (
 )
 from todo_cli.domain import TodoStatus, Priority
 
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    """Application lifespan hooks."""
+    # Database and storage bridge are initialized on first access
+    yield
+
+
 # Initialize FastAPI app
 app = FastAPI(
     title="Todo CLI Web",
     description="Terminal-inspired task management",
     version="1.0.0",
+    lifespan=lifespan,
 )
 
 # Add session middleware for flash messages
@@ -57,13 +66,6 @@ def url_for(name: str, **path_params):
 
 templates.env.globals['url_for'] = url_for
 templates.env.globals['get_flashed_messages'] = lambda **kwargs: []  # Flash messages not implemented yet
-
-@app.on_event("startup")
-async def startup_event():
-    """Initialize application on startup"""
-    # Database and storage bridge are initialized on first access
-    pass
-
 
 # ============================================================================
 # Template Context Processors

--- a/src/todo_cli/webapp/models.py
+++ b/src/todo_cli/webapp/models.py
@@ -4,7 +4,7 @@ Pydantic models for API validation
 
 from datetime import datetime
 from typing import Optional, List
-from pydantic import BaseModel, EmailStr, Field, validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 
 # ============================================================================
@@ -34,8 +34,7 @@ class UserResponse(UserBase):
     id: str
     created_at: datetime
     
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # ============================================================================
@@ -51,7 +50,8 @@ class TaskBase(BaseModel):
     project_id: Optional[str] = None
     tags: Optional[List[str]] = []
     
-    @validator('tags')
+    @field_validator("tags")
+    @classmethod
     def validate_tags(cls, v):
         """Validate and clean tags"""
         if v is None:
@@ -74,7 +74,8 @@ class TaskUpdate(BaseModel):
     tags: Optional[List[str]] = None
     completed: Optional[bool] = None
     
-    @validator('tags')
+    @field_validator("tags")
+    @classmethod
     def validate_tags(cls, v):
         """Validate and clean tags"""
         if v is None:
@@ -92,8 +93,7 @@ class TaskResponse(TaskBase):
     is_overdue: bool = False
     is_today: bool = False
     
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TaskToggle(BaseModel):
@@ -133,8 +133,7 @@ class ProjectResponse(ProjectBase):
     created_at: datetime
     updated_at: datetime
     
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # ============================================================================


### PR DESCRIPTION
### Motivation

- Update model validation and configuration to be compatible with Pydantic v2 APIs and improve clarity in sync/provider settings.
- Replace the legacy FastAPI startup event with a proper lifespan handler to simplify application initialization.

### Description

- Replaced `pydantic` `validator` decorators with the v2 `field_validator` API in `src/todo_cli/sync/app_sync_config.py` and `src/todo_cli/webapp/models.py` and adapted validators to classmethod-style signatures where required. 
- Swapped `Config` inner classes to the v2 `model_config = ConfigDict(from_attributes=True)` pattern in response models in `src/todo_cli/webapp/models.py`.
- Adjusted imports from `pydantic` to include `field_validator` and `ConfigDict` where needed.
- Added an async `lifespan` context manager in `src/todo_cli/webapp/app.py` and passed it to `FastAPI(...)`, removing the previous `@app.on_event("startup")` no-op function.
- Minor file formatting/EOF normalization in `src/todo_cli/sync/app_sync_config.py`.

### Testing

- Ran the project's unit test suite with `pytest` and all tests completed successfully. 
- Ran static checks/linting (project linters) and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbeab962948332918393786c626540)