### PR TITLE
Introduce application layer, core errors/logging, storage codec, and Todo invariants; add tests

### DIFF
--- a/docs/REFACTOR_REVIEW_PLAN.md
+++ b/docs/REFACTOR_REVIEW_PLAN.md
@@ -1,0 +1,175 @@
+# Todo CLI In-Depth Refactor Review & Improvement Plan
+
+## Executive Summary
+
+The application has impressive feature breadth, but the current implementation has signs of **feature accretion without strong architectural boundaries**. The biggest opportunities are:
+
+1. **Decompose large mixed-responsibility modules** (especially CLI + storage + sync).
+2. **Establish stronger domain and validation invariants** (currently partially disabled).
+3. **Normalize error handling, logging, and dependency wiring**.
+4. **Reduce duplicated parsing/serialization logic and tighten typed interfaces**.
+5. **Introduce a staged modernization roadmap with measurable quality gates**.
+
+---
+
+## What I Reviewed
+
+- Project/package layout and dependencies.
+- CLI entrypoint and command module structure.
+- Domain model quality and invariants.
+- Storage parsing/serialization strategy.
+- Sync subsystem boundaries.
+- AI provider abstraction and integration style.
+
+---
+
+## Key Refactor Opportunities
+
+### 1) Strengthen module boundaries and layering
+
+**Current signals**
+- The CLI module `tasks.py` performs command wiring, formatting, parsing orchestration, storage access, and business behavior directly. This creates a “god module” risk over time.
+- Service and sync modules include both domain logic and infrastructure concerns in single files.
+
+**Refactor direction**
+- Adopt a simple layered structure:
+  - `domain/` (entities, value objects, invariants)
+  - `application/` (use-cases / command handlers)
+  - `infrastructure/` (file storage, adapters, provider clients)
+  - `interfaces/cli` and `interfaces/web`
+- Keep Click command functions thin and delegate behavior to application services.
+
+**Outcome**
+- Better testability, easier feature additions, reduced merge conflicts.
+
+### 2) Re-enable and formalize domain validation
+
+**Current signals**
+- The `Todo` model explicitly has validation disabled (`pass` with comment about temporary disable), indicating invariants are not enforced consistently.
+
+**Refactor direction**
+- Introduce explicit validation methods or pydantic-backed command DTOs before entity construction.
+- Reinstate invariant checks in `__post_init__` for status/completed/progress/date consistency.
+- Add regression tests for parsing edge cases that previously required disabling validation.
+
+**Outcome**
+- Less silent data corruption and fewer downstream bugs.
+
+### 3) Split storage concerns and harden parsing contracts
+
+**Current signals**
+- `storage.py` combines: dependency fallback import logic, markdown parsing, ID comment rewriting, repository-like operations, and time/date normalization.
+- Frontmatter fallback and markdown reconstruction are mixed with business mapping.
+
+**Refactor direction**
+- Extract into focused modules:
+  - `storage/frontmatter_codec.py`
+  - `storage/markdown_task_codec.py`
+  - `storage/repository.py`
+- Add a formal `TodoSerializationError` hierarchy and avoid silent exception swallowing where possible.
+- Add round-trip property tests (`Todo -> markdown -> Todo`) with fixtures.
+
+**Outcome**
+- More reliable persistence and easier migration to alternate backends.
+
+### 4) Standardize error handling and logging
+
+**Current signals**
+- Mixed patterns: direct `print`, `sys.exit`, broad `except Exception`, and inconsistent user-facing error reporting.
+
+**Refactor direction**
+- Introduce a unified error taxonomy (config, validation, storage, provider/network, auth).
+- Route infrastructure logs through `logging` with configurable verbosity.
+- Keep CLI layer responsible for presentation and exit codes only.
+
+**Outcome**
+- Debuggability in production and cleaner user error messages.
+
+### 5) Improve sync architecture for extensibility
+
+**Current signals**
+- `sync/service.py` contains many enums, dataclasses, adapter logic, provider branching, and filesystem/process concerns in one place.
+
+**Refactor direction**
+- Split into:
+  - sync domain models (`sync/models.py`)
+  - conflict engine (`sync/conflicts.py`)
+  - provider interface (`sync/providers/base.py`)
+  - provider implementations (`sync/providers/*.py`)
+  - orchestration service (`sync/service.py`)
+- Prefer explicit capability interfaces (e.g., supports incremental sync, supports delete propagation).
+
+**Outcome**
+- Easier provider onboarding and fewer regressions across adapters.
+
+### 6) Tighten AI integration boundaries
+
+**Current signals**
+- AI service API is a good start, but prompt construction, provider config resolution, and JSON parsing fallback are concentrated in one class.
+
+**Refactor direction**
+- Separate:
+  - `ai/providers/*`
+  - `ai/prompts/*`
+  - `ai/parsers/*`
+  - `ai/use_cases/*`
+- Add contract tests with deterministic fake providers to validate structured outputs.
+
+**Outcome**
+- Safer upgrades of provider SDKs/models and more predictable behavior.
+
+### 7) Reduce duplication across interfaces (CLI/Web/iOS)
+
+**Current signals**
+- Multiple entry points imply risk of duplicated business rules drifting across command, API, and mobile-support code.
+
+**Refactor direction**
+- Move core use-cases into application layer and expose them to CLI + API with shared DTOs.
+- Keep transport-specific mapping in interface layers only.
+
+**Outcome**
+- Single source of truth for behavior.
+
+---
+
+## Proposed Implementation Plan (Phased)
+
+### Phase 1 (1–2 weeks): Safety + Baseline
+- Add architectural decision record (ADR) for layering and coding conventions.
+- Re-enable validation with feature flag if needed (`strict_validation=false` default).
+- Introduce centralized error types and logging scaffold.
+- Add key characterization tests around add/list/done flows and markdown round-trip.
+
+### Phase 2 (2–3 weeks): Structural Extraction
+- Extract storage codecs/repository.
+- Extract CLI command handlers into application services.
+- Split sync models/interfaces from implementation.
+
+### Phase 3 (2–4 weeks): Provider & Integration Cleanup
+- Refactor sync providers to explicit contracts.
+- Refactor AI providers/prompts/parsers with contract tests.
+- Add dependency injection container/factory for CLI + API bootstrap.
+
+### Phase 4 (ongoing): Quality Gates and Performance
+- Add CI gates: mypy (incremental strictness), coverage thresholds by package, lint.
+- Add smoke benchmarks for loading large project files and sync throughput.
+- Add observability for failures (structured logs + optional telemetry hooks).
+
+---
+
+## Recommended Priorities
+
+1. **P0:** Domain validation and storage round-trip correctness.
+2. **P1:** CLI/application decoupling and unified error handling.
+3. **P1:** Sync decomposition for maintainability.
+4. **P2:** AI boundary cleanup and shared DTOs across interfaces.
+
+---
+
+## Suggested Success Metrics
+
+- 30–50% reduction in average module size for top 5 largest Python files.
+- 90%+ pass rate on new round-trip/characterization tests before major refactors.
+- Fewer broad `except Exception` usages in application logic.
+- Reduced change surface: feature PRs touch fewer layers/files on average.
+

--- a/src/todo_cli/application/__init__.py
+++ b/src/todo_cli/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application-layer use cases for Todo CLI."""

--- a/src/todo_cli/application/task_commands.py
+++ b/src/todo_cli/application/task_commands.py
@@ -1,0 +1,64 @@
+"""Application-layer task command handlers."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..config import ConfigModel
+from ..core.errors import ValidationError, StorageError
+from ..domain import TaskBuilder, parse_task_input, Todo
+from ..storage import Storage
+
+
+@dataclass
+class AddTaskResult:
+    todo: Todo
+    suggestions: list[str]
+
+
+def add_task_from_input(
+    *,
+    storage: Storage,
+    config: ConfigModel,
+    input_text: str,
+    project: Optional[str] = None,
+) -> AddTaskResult:
+    """Parse natural-language input and persist a new task."""
+    all_todos: list[Todo] = []
+    projects = storage.list_projects() or [config.default_project]
+
+    for proj_name in projects:
+        _, todos = storage.load_project(proj_name)
+        if todos:
+            all_todos.extend(todos)
+
+    available_projects = list({t.project for t in all_todos if t.project})
+    available_tags = list({tag for t in all_todos for tag in t.tags})
+    available_people = list({person for t in all_todos for person in t.assignees})
+
+    parsed, errors, suggestions = parse_task_input(
+        input_text,
+        config,
+        project_hint=project or config.default_project,
+        available_projects=available_projects,
+        available_tags=available_tags,
+        available_people=available_people,
+    )
+
+    blocking_errors = [e for e in errors if e.severity == "error"]
+    if blocking_errors:
+        joined = "; ".join(e.message for e in blocking_errors)
+        raise ValidationError(joined)
+
+    target_project = parsed.project or project or config.default_project
+    proj, existing_todos = storage.load_project(target_project)
+    next_id = (max(todo.id for todo in existing_todos) + 1) if existing_todos else 1
+
+    builder = TaskBuilder(config)
+    todo = builder.build(parsed, next_id)
+    todo.project = target_project
+
+    existing_todos.append(todo)
+    if not storage.save_project(proj, existing_todos):
+        raise StorageError("Failed to save todo")
+
+    return AddTaskResult(todo=todo, suggestions=suggestions)

--- a/src/todo_cli/cli/tasks.py
+++ b/src/todo_cli/cli/tasks.py
@@ -12,7 +12,9 @@ from rich.panel import Panel
 from ..utils.datetime import ensure_aware, max_utc
 
 from ..config import get_config, load_config
+from ..core.errors import ValidationError
 from ..storage import Storage
+from ..application.task_commands import add_task_from_input
 from ..domain import (
     Todo,
     TodoStatus,
@@ -138,87 +140,32 @@ def add(input_text, project, dry_run, suggest):
     try:
         storage = get_storage()
         config = get_config()
-        
-        # Get available data for suggestions
-        all_todos = []
-        projects = storage.list_projects()
-        if not projects:
-            projects = [config.default_project]
-        
-        for proj_name in projects:
-            proj, todos = storage.load_project(proj_name)
-            if todos:
-                all_todos.extend(todos)
-        
-        available_projects = list(set(t.project for t in all_todos if t.project))
-        available_tags = list(set(tag for t in all_todos for tag in t.tags))
-        available_people = list(set(person for t in all_todos for person in t.assignees))
-        
-        # Parse the input
-        parsed, errors, suggestions = parse_task_input(
-            input_text, 
-            config, 
-            project_hint=project or config.default_project,
-            available_projects=available_projects, 
-            available_tags=available_tags, 
-            available_people=available_people
-        )
-        
-        # Show parsing errors
-        if errors:
-            get_console().print("[bold yellow]⚠️  Parsing Issues:[/bold yellow]")
-            for error in errors:
-                if error.severity == "error":
-                    get_console().print(f"  [red]❌ {error.message}[/red]")
-                    for suggestion in error.suggestions:
-                        get_console().print(f"     [blue]💡 {suggestion}[/blue]")
-                elif error.severity == "warning":
-                    get_console().print(f"  [yellow]⚠️  {error.message}[/yellow]")
-            
-            # Don't proceed if there are blocking errors
-            if any(e.severity == "error" for e in errors):
-                sys.exit(1)
-        
-        # Show suggestions if requested
-        if suggest or suggestions:
-            if suggestions:
-                get_console().print("[bold blue]💡 Suggestions:[/bold blue]")
-                for suggestion in suggestions:
-                    get_console().print(f"  [blue]{suggestion}[/blue]")
-            
-            if suggest:
-                return
-        
-        # Get next todo ID for the project
-        target_project = parsed.project or project or config.default_project
-        proj, existing_todos = storage.load_project(target_project)
-        
-        if existing_todos:
-            next_id = max(todo.id for todo in existing_todos) + 1
-        else:
-            next_id = 1
-        
-        # Convert ParsedTask to Todo using TaskBuilder
-        builder = TaskBuilder(config)
-        todo = builder.build(parsed, next_id)
-        todo.project = target_project
-        
+
         if dry_run:
+            parsed, _, _ = parse_task_input(
+                input_text,
+                config,
+                project_hint=project or config.default_project,
+            )
+            preview_todo = TaskBuilder(config).build(parsed, 1)
             get_console().print("[bold yellow]🔍 DRY RUN - Would create:[/bold yellow]")
-            get_console().print(f"  {format_todo_for_display(todo)}")
+            get_console().print(f"  {format_todo_for_display(preview_todo, show_id=False)}")
             return
-        
-        # Add the todo
-        existing_todos.append(todo)
-        
-        # Save the project
-        if storage.save_project(proj, existing_todos):
-            get_console().print(f"[green]✅ Added:[/green] {format_todo_for_display(todo)}")
-        else:
-            get_console().print("[red]❌ Failed to save todo[/red]")
-            sys.exit(1)
-            
-    except Exception as e:
+
+        result = add_task_from_input(
+            storage=storage,
+            config=config,
+            input_text=input_text,
+            project=project,
+        )
+        if suggest and result.suggestions:
+            get_console().print("[bold blue]💡 Suggestions:[/bold blue]")
+            for suggestion in result.suggestions:
+                get_console().print(f"  [blue]{suggestion}[/blue]")
+
+        get_console().print(f"[green]✅ Added:[/green] {format_todo_for_display(result.todo)}")
+
+    except (ValidationError, ParseError) as e:
         get_console().print(f"[red]❌ Error creating todo: {e}[/red]")
         sys.exit(1)
 

--- a/src/todo_cli/core/__init__.py
+++ b/src/todo_cli/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core cross-cutting concerns (errors, logging, etc.)."""

--- a/src/todo_cli/core/errors.py
+++ b/src/todo_cli/core/errors.py
@@ -1,0 +1,21 @@
+"""Centralized application error taxonomy."""
+
+
+class TodoCliError(Exception):
+    """Base error for all Todo CLI domain/application failures."""
+
+
+class ValidationError(TodoCliError):
+    """Raised when input or entity validation fails."""
+
+
+class ConfigurationError(TodoCliError):
+    """Raised when configuration is invalid or unavailable."""
+
+
+class StorageError(TodoCliError):
+    """Raised for persistence and serialization errors."""
+
+
+class ProviderError(TodoCliError):
+    """Raised for external provider/network failures."""

--- a/src/todo_cli/core/logging.py
+++ b/src/todo_cli/core/logging.py
@@ -1,0 +1,12 @@
+"""Shared logging setup helpers."""
+
+import logging
+
+
+def configure_logging(verbose: bool = False) -> None:
+    """Configure root logging level and format once for CLI/API entrypoints."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )

--- a/src/todo_cli/domain/todo.py
+++ b/src/todo_cli/domain/todo.py
@@ -117,8 +117,34 @@ class Todo:
         # Update modified timestamp
         self.modified = now_utc()
         
-        # Temporarily disable validation to isolate parsing issue
-        pass
+        self._normalize_state()
+
+    def _normalize_state(self):
+        """Normalize and enforce cross-field state invariants."""
+        # Keep progress in valid bounds
+        self.progress = max(0.0, min(1.0, float(self.progress)))
+
+        # Completed status and completed flag must remain consistent
+        if self.status == TodoStatus.COMPLETED:
+            self.completed = True
+        elif self.completed and self.status != TodoStatus.COMPLETED:
+            self.status = TodoStatus.COMPLETED
+
+        # Promote fully complete progress to completed state
+        if self.progress >= 1.0 and not self.completed:
+            self.completed = True
+            self.status = TodoStatus.COMPLETED
+
+        # Ensure completed tasks always have completion date and full progress
+        if self.completed:
+            if self.completed_date is None:
+                self.completed_date = now_utc()
+            self.progress = 1.0
+
+        # If status is not completed, avoid stale completion metadata
+        if self.status != TodoStatus.COMPLETED and not self.completed:
+            self.completed_date = None
+            self.completed_by = None
     
     def complete(self, completed_by: Optional[str] = None):
         """Mark the task as completed."""

--- a/src/todo_cli/infrastructure/__init__.py
+++ b/src/todo_cli/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure adapters and persistence utilities."""

--- a/src/todo_cli/infrastructure/storage/__init__.py
+++ b/src/todo_cli/infrastructure/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage infrastructure modules and codecs."""

--- a/src/todo_cli/infrastructure/storage/markdown_task_codec.py
+++ b/src/todo_cli/infrastructure/storage/markdown_task_codec.py
@@ -1,0 +1,23 @@
+"""Markdown codec for Todo lines with inline metadata and ID comments."""
+
+from typing import Optional, Tuple
+
+from ...storage import TodoMarkdownFormat
+from ...domain import Todo
+
+
+def todo_to_markdown(todo: Todo) -> str:
+    """Serialize Todo to markdown task representation."""
+    return TodoMarkdownFormat.to_markdown(todo)
+
+
+def todo_from_markdown(line: str, project: str = "inbox", line_id: Optional[int] = None) -> Optional[Todo]:
+    """Deserialize markdown task line into Todo."""
+    return TodoMarkdownFormat.from_markdown(line, project=project, line_id=line_id)
+
+
+def strip_id_comments(text: str) -> Tuple[Optional[int], str]:
+    """Extract last embedded ID comment and return cleaned text."""
+    from ...storage import extract_last_id_and_strip
+
+    return extract_last_id_and_strip(text)

--- a/tests/test_application_task_commands.py
+++ b/tests/test_application_task_commands.py
@@ -1,0 +1,24 @@
+"""Tests for application-layer task command handlers."""
+
+from todo_cli.application.task_commands import add_task_from_input
+from todo_cli.config import ConfigModel
+from todo_cli.storage import Storage
+
+
+def test_add_task_from_input_persists_task(tmp_path):
+    config = ConfigModel(data_dir=str(tmp_path / "todo_data"), backup_dir=str(tmp_path / "todo_backups"))
+    storage = Storage(config)
+
+    result = add_task_from_input(
+        storage=storage,
+        config=config,
+        input_text="Write tests for application layer @dev ~high",
+        project="inbox",
+    )
+
+    assert result.todo.id == 1
+    assert result.todo.text.startswith("Write tests")
+
+    _, todos = storage.load_project("inbox")
+    assert len(todos) == 1
+    assert todos[0].text == result.todo.text

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -200,3 +200,21 @@ class TestTodo:
         assert data["tags"] == ["urgent", "work"]
         assert data["assignees"] == ["john", "jane"]
         assert data["status"] == "pending"
+    def test_todo_post_init_normalizes_completed_status(self):
+        """Test post-init consistency between status and completed fields."""
+        todo = Todo(id=99, text="Done task", completed=True)
+
+        assert todo.status == TodoStatus.COMPLETED
+        assert todo.completed is True
+        assert todo.completed_date is not None
+        assert todo.progress == 1.0
+
+    def test_todo_post_init_clamps_progress(self):
+        """Test post-init clamps invalid progress values."""
+        low = Todo(id=100, text="Low progress", progress=-2)
+        high = Todo(id=101, text="High progress", progress=3)
+
+        assert low.progress == 0.0
+        assert high.progress == 1.0
+        assert high.completed is True
+        assert high.status == TodoStatus.COMPLETED


### PR DESCRIPTION
### Motivation

- Decouple CLI behavior from domain and persistence to improve testability and maintainability.  
- Re-enable and formalize domain invariants for `Todo` to avoid silent data inconsistencies.  
- Centralize cross-cutting concerns (errors, logging) and move storage serialization into focused codecs for clearer boundaries.

### Description

- Add an application layer with `todo_cli.application.task_commands.add_task_from_input` to encapsulate parsing, suggestions, ID allocation, and persistence.  
- Refactor the CLI `add` command in `todo_cli.cli.tasks` to delegate to the new application use-case and simplify dry-run / suggestion presentation.  
- Introduce core modules `todo_cli.core.errors` and `todo_cli.core.logging` to provide a unified error taxonomy and logging setup.  
- Restore and enforce `Todo` post-initialization invariants in `todo_cli.domain.todo` via `_normalize_state`, clamping `progress`, reconciling `status`/`completed`, and ensuring completion metadata.  
- Add an infrastructure storage codec `todo_cli.infrastructure.storage.markdown_task_codec` to isolate markdown serialization/parsing.  
- Add an in-repo review plan `docs/REFACTOR_REVIEW_PLAN.md` describing further decomposition and modernization guidance.  
- Add unit tests for the application command handler (`tests/test_application_task_commands.py`) and augment `tests/test_todo.py` with `post_init` normalization and progress clamping tests.

### Testing

- Ran the unit test suite with `pytest` covering the new application handler and `Todo` behavior.  
- Executed `tests/test_application_task_commands.py` which verifies `add_task_from_input` persists a created task, and it passed.  
- Executed updated `tests/test_todo.py` which verifies `__post_init__` normalization and progress clamping, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60701b9b08332998bde16e125f17b)