### PR TITLE
Introduce application layer, repository, core errors/logging, and re-enable domain invariants

### DIFF
--- a/docs/REFACTOR_REVIEW_PLAN.md
+++ b/docs/REFACTOR_REVIEW_PLAN.md
@@ -1,0 +1,175 @@
+# Todo CLI In-Depth Refactor Review & Improvement Plan
+
+## Executive Summary
+
+The application has impressive feature breadth, but the current implementation has signs of **feature accretion without strong architectural boundaries**. The biggest opportunities are:
+
+1. **Decompose large mixed-responsibility modules** (especially CLI + storage + sync).
+2. **Establish stronger domain and validation invariants** (currently partially disabled).
+3. **Normalize error handling, logging, and dependency wiring**.
+4. **Reduce duplicated parsing/serialization logic and tighten typed interfaces**.
+5. **Introduce a staged modernization roadmap with measurable quality gates**.
+
+---
+
+## What I Reviewed
+
+- Project/package layout and dependencies.
+- CLI entrypoint and command module structure.
+- Domain model quality and invariants.
+- Storage parsing/serialization strategy.
+- Sync subsystem boundaries.
+- AI provider abstraction and integration style.
+
+---
+
+## Key Refactor Opportunities
+
+### 1) Strengthen module boundaries and layering
+
+**Current signals**
+- The CLI module `tasks.py` performs command wiring, formatting, parsing orchestration, storage access, and business behavior directly. This creates a “god module” risk over time.
+- Service and sync modules include both domain logic and infrastructure concerns in single files.
+
+**Refactor direction**
+- Adopt a simple layered structure:
+  - `domain/` (entities, value objects, invariants)
+  - `application/` (use-cases / command handlers)
+  - `infrastructure/` (file storage, adapters, provider clients)
+  - `interfaces/cli` and `interfaces/web`
+- Keep Click command functions thin and delegate behavior to application services.
+
+**Outcome**
+- Better testability, easier feature additions, reduced merge conflicts.
+
+### 2) Re-enable and formalize domain validation
+
+**Current signals**
+- The `Todo` model explicitly has validation disabled (`pass` with comment about temporary disable), indicating invariants are not enforced consistently.
+
+**Refactor direction**
+- Introduce explicit validation methods or pydantic-backed command DTOs before entity construction.
+- Reinstate invariant checks in `__post_init__` for status/completed/progress/date consistency.
+- Add regression tests for parsing edge cases that previously required disabling validation.
+
+**Outcome**
+- Less silent data corruption and fewer downstream bugs.
+
+### 3) Split storage concerns and harden parsing contracts
+
+**Current signals**
+- `storage.py` combines: dependency fallback import logic, markdown parsing, ID comment rewriting, repository-like operations, and time/date normalization.
+- Frontmatter fallback and markdown reconstruction are mixed with business mapping.
+
+**Refactor direction**
+- Extract into focused modules:
+  - `storage/frontmatter_codec.py`
+  - `storage/markdown_task_codec.py`
+  - `storage/repository.py`
+- Add a formal `TodoSerializationError` hierarchy and avoid silent exception swallowing where possible.
+- Add round-trip property tests (`Todo -> markdown -> Todo`) with fixtures.
+
+**Outcome**
+- More reliable persistence and easier migration to alternate backends.
+
+### 4) Standardize error handling and logging
+
+**Current signals**
+- Mixed patterns: direct `print`, `sys.exit`, broad `except Exception`, and inconsistent user-facing error reporting.
+
+**Refactor direction**
+- Introduce a unified error taxonomy (config, validation, storage, provider/network, auth).
+- Route infrastructure logs through `logging` with configurable verbosity.
+- Keep CLI layer responsible for presentation and exit codes only.
+
+**Outcome**
+- Debuggability in production and cleaner user error messages.
+
+### 5) Improve sync architecture for extensibility
+
+**Current signals**
+- `sync/service.py` contains many enums, dataclasses, adapter logic, provider branching, and filesystem/process concerns in one place.
+
+**Refactor direction**
+- Split into:
+  - sync domain models (`sync/models.py`)
+  - conflict engine (`sync/conflicts.py`)
+  - provider interface (`sync/providers/base.py`)
+  - provider implementations (`sync/providers/*.py`)
+  - orchestration service (`sync/service.py`)
+- Prefer explicit capability interfaces (e.g., supports incremental sync, supports delete propagation).
+
+**Outcome**
+- Easier provider onboarding and fewer regressions across adapters.
+
+### 6) Tighten AI integration boundaries
+
+**Current signals**
+- AI service API is a good start, but prompt construction, provider config resolution, and JSON parsing fallback are concentrated in one class.
+
+**Refactor direction**
+- Separate:
+  - `ai/providers/*`
+  - `ai/prompts/*`
+  - `ai/parsers/*`
+  - `ai/use_cases/*`
+- Add contract tests with deterministic fake providers to validate structured outputs.
+
+**Outcome**
+- Safer upgrades of provider SDKs/models and more predictable behavior.
+
+### 7) Reduce duplication across interfaces (CLI/Web/iOS)
+
+**Current signals**
+- Multiple entry points imply risk of duplicated business rules drifting across command, API, and mobile-support code.
+
+**Refactor direction**
+- Move core use-cases into application layer and expose them to CLI + API with shared DTOs.
+- Keep transport-specific mapping in interface layers only.
+
+**Outcome**
+- Single source of truth for behavior.
+
+---
+
+## Proposed Implementation Plan (Phased)
+
+### Phase 1 (1–2 weeks): Safety + Baseline
+- Add architectural decision record (ADR) for layering and coding conventions.
+- Re-enable validation with feature flag if needed (`strict_validation=false` default).
+- Introduce centralized error types and logging scaffold.
+- Add key characterization tests around add/list/done flows and markdown round-trip.
+
+### Phase 2 (2–3 weeks): Structural Extraction
+- Extract storage codecs/repository.
+- Extract CLI command handlers into application services.
+- Split sync models/interfaces from implementation.
+
+### Phase 3 (2–4 weeks): Provider & Integration Cleanup
+- Refactor sync providers to explicit contracts.
+- Refactor AI providers/prompts/parsers with contract tests.
+- Add dependency injection container/factory for CLI + API bootstrap.
+
+### Phase 4 (ongoing): Quality Gates and Performance
+- Add CI gates: mypy (incremental strictness), coverage thresholds by package, lint.
+- Add smoke benchmarks for loading large project files and sync throughput.
+- Add observability for failures (structured logs + optional telemetry hooks).
+
+---
+
+## Recommended Priorities
+
+1. **P0:** Domain validation and storage round-trip correctness.
+2. **P1:** CLI/application decoupling and unified error handling.
+3. **P1:** Sync decomposition for maintainability.
+4. **P2:** AI boundary cleanup and shared DTOs across interfaces.
+
+---
+
+## Suggested Success Metrics
+
+- 30–50% reduction in average module size for top 5 largest Python files.
+- 90%+ pass rate on new round-trip/characterization tests before major refactors.
+- Fewer broad `except Exception` usages in application logic.
+- Reduced change surface: feature PRs touch fewer layers/files on average.
+

--- a/src/todo_cli/application/__init__.py
+++ b/src/todo_cli/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application-layer use cases for Todo CLI."""

--- a/src/todo_cli/application/task_commands.py
+++ b/src/todo_cli/application/task_commands.py
@@ -29,7 +29,10 @@ def add_task_from_input(
     projects = repository.list_projects() or [config.default_project]
 
     for proj_name in projects:
-        _, todos = repository.load_project(proj_name)
+        try:
+            _, todos = repository.load_project(proj_name)
+        except StorageError:
+            todos = []
         if todos:
             all_todos.extend(todos)
 
@@ -53,7 +56,8 @@ def add_task_from_input(
 
     target_project = parsed.project or project or config.default_project
     proj, existing_todos = repository.load_project(target_project)
-    next_id = max((todo.id for todo in existing_todos), default=0) + 1
+    # Use the globally unique next ID across all projects.
+    next_id = repository.next_todo_id()
 
     builder = TaskBuilder(config)
     todo = builder.build(parsed, next_id)

--- a/src/todo_cli/application/task_commands.py
+++ b/src/todo_cli/application/task_commands.py
@@ -1,0 +1,66 @@
+"""Application-layer task command handlers."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..config import ConfigModel
+from ..core.errors import ValidationError, StorageError
+from ..domain import TaskBuilder, parse_task_input, Todo
+from ..storage import Storage
+from ..infrastructure.storage.repository import TodoRepository
+
+
+@dataclass
+class AddTaskResult:
+    todo: Todo
+    suggestions: list[str]
+
+
+def add_task_from_input(
+    *,
+    storage: Storage,
+    config: ConfigModel,
+    input_text: str,
+    project: Optional[str] = None,
+) -> AddTaskResult:
+    """Parse natural-language input and persist a new task."""
+    repository = TodoRepository(storage)
+    all_todos: list[Todo] = []
+    projects = repository.list_projects() or [config.default_project]
+
+    for proj_name in projects:
+        _, todos = repository.load_project(proj_name)
+        if todos:
+            all_todos.extend(todos)
+
+    available_projects = list({t.project for t in all_todos if t.project})
+    available_tags = list({tag for t in all_todos for tag in t.tags})
+    available_people = list({person for t in all_todos for person in t.assignees})
+
+    parsed, errors, suggestions = parse_task_input(
+        input_text,
+        config,
+        project_hint=project or config.default_project,
+        available_projects=available_projects,
+        available_tags=available_tags,
+        available_people=available_people,
+    )
+
+    blocking_errors = [e for e in errors if e.severity == "error"]
+    if blocking_errors:
+        joined = "; ".join(e.message for e in blocking_errors)
+        raise ValidationError(joined)
+
+    target_project = parsed.project or project or config.default_project
+    proj, existing_todos = repository.load_project(target_project)
+    next_id = repository.next_todo_id(target_project)
+
+    builder = TaskBuilder(config)
+    todo = builder.build(parsed, next_id)
+    todo.project = target_project
+
+    existing_todos.append(todo)
+    if not repository.save_project(proj, existing_todos):
+        raise StorageError("Failed to save todo")
+
+    return AddTaskResult(todo=todo, suggestions=suggestions)

--- a/src/todo_cli/application/task_commands.py
+++ b/src/todo_cli/application/task_commands.py
@@ -33,9 +33,9 @@ def add_task_from_input(
         if todos:
             all_todos.extend(todos)
 
-    available_projects = list({t.project for t in all_todos if t.project})
-    available_tags = list({tag for t in all_todos for tag in t.tags})
-    available_people = list({person for t in all_todos for person in t.assignees})
+    available_projects = sorted({t.project for t in all_todos if t.project})
+    available_tags = sorted({tag for t in all_todos for tag in t.tags})
+    available_people = sorted({person for t in all_todos for person in t.assignees})
 
     parsed, errors, suggestions = parse_task_input(
         input_text,

--- a/src/todo_cli/application/task_commands.py
+++ b/src/todo_cli/application/task_commands.py
@@ -53,7 +53,7 @@ def add_task_from_input(
 
     target_project = parsed.project or project or config.default_project
     proj, existing_todos = repository.load_project(target_project)
-    next_id = repository.next_todo_id(target_project)
+    next_id = max((todo.id for todo in existing_todos), default=0) + 1
 
     builder = TaskBuilder(config)
     todo = builder.build(parsed, next_id)

--- a/src/todo_cli/cli/tasks.py
+++ b/src/todo_cli/cli/tasks.py
@@ -12,7 +12,7 @@ from rich.panel import Panel
 from ..utils.datetime import ensure_aware, max_utc
 
 from ..config import get_config, load_config
-from ..core.errors import TodoCliError, ValidationError
+from ..core.errors import TodoCliError
 from ..storage import Storage
 from ..application.task_commands import add_task_from_input
 from ..domain import (

--- a/src/todo_cli/cli/tasks.py
+++ b/src/todo_cli/cli/tasks.py
@@ -152,16 +152,26 @@ def add(input_text, project, dry_run, suggest):
             get_console().print(f"  {format_todo_for_display(preview_todo, show_id=False)}")
             return
 
+        if suggest:
+            _, _, suggestions = parse_task_input(
+                input_text,
+                config,
+                project_hint=project or config.default_project,
+            )
+            get_console().print("[bold blue]💡 Suggestions:[/bold blue]")
+            if suggestions:
+                for suggestion in suggestions:
+                    get_console().print(f"  [blue]{suggestion}[/blue]")
+            else:
+                get_console().print("  [dim]No suggestions available.[/dim]")
+            return
+
         result = add_task_from_input(
             storage=storage,
             config=config,
             input_text=input_text,
             project=project,
         )
-        if suggest and result.suggestions:
-            get_console().print("[bold blue]💡 Suggestions:[/bold blue]")
-            for suggestion in result.suggestions:
-                get_console().print(f"  [blue]{suggestion}[/blue]")
 
         get_console().print(f"[green]✅ Added:[/green] {format_todo_for_display(result.todo)}")
 

--- a/src/todo_cli/cli/tasks.py
+++ b/src/todo_cli/cli/tasks.py
@@ -142,11 +142,20 @@ def add(input_text, project, dry_run, suggest):
         config = get_config()
 
         if dry_run:
-            parsed, _, _ = parse_task_input(
+            parsed, errors, suggestions = parse_task_input(
                 input_text,
                 config,
                 project_hint=project or config.default_project,
             )
+            blocking_errors = [e for e in errors if e.severity == "error"]
+            if blocking_errors:
+                for err in blocking_errors:
+                    get_console().print(f"[red]❌ {err.message}[/red]")
+                sys.exit(1)
+            if suggestions:
+                get_console().print("[bold blue]💡 Suggestions:[/bold blue]")
+                for suggestion in suggestions:
+                    get_console().print(f"  [blue]{suggestion}[/blue]")
             preview_todo = TaskBuilder(config).build(parsed, 1)
             get_console().print("[bold yellow]🔍 DRY RUN - Would create:[/bold yellow]")
             get_console().print(f"  {format_todo_for_display(preview_todo, show_id=False)}")

--- a/src/todo_cli/cli/tasks.py
+++ b/src/todo_cli/cli/tasks.py
@@ -12,7 +12,9 @@ from rich.panel import Panel
 from ..utils.datetime import ensure_aware, max_utc
 
 from ..config import get_config, load_config
+from ..core.errors import TodoCliError, ValidationError
 from ..storage import Storage
+from ..application.task_commands import add_task_from_input
 from ..domain import (
     Todo,
     TodoStatus,
@@ -138,87 +140,32 @@ def add(input_text, project, dry_run, suggest):
     try:
         storage = get_storage()
         config = get_config()
-        
-        # Get available data for suggestions
-        all_todos = []
-        projects = storage.list_projects()
-        if not projects:
-            projects = [config.default_project]
-        
-        for proj_name in projects:
-            proj, todos = storage.load_project(proj_name)
-            if todos:
-                all_todos.extend(todos)
-        
-        available_projects = list(set(t.project for t in all_todos if t.project))
-        available_tags = list(set(tag for t in all_todos for tag in t.tags))
-        available_people = list(set(person for t in all_todos for person in t.assignees))
-        
-        # Parse the input
-        parsed, errors, suggestions = parse_task_input(
-            input_text, 
-            config, 
-            project_hint=project or config.default_project,
-            available_projects=available_projects, 
-            available_tags=available_tags, 
-            available_people=available_people
-        )
-        
-        # Show parsing errors
-        if errors:
-            get_console().print("[bold yellow]⚠️  Parsing Issues:[/bold yellow]")
-            for error in errors:
-                if error.severity == "error":
-                    get_console().print(f"  [red]❌ {error.message}[/red]")
-                    for suggestion in error.suggestions:
-                        get_console().print(f"     [blue]💡 {suggestion}[/blue]")
-                elif error.severity == "warning":
-                    get_console().print(f"  [yellow]⚠️  {error.message}[/yellow]")
-            
-            # Don't proceed if there are blocking errors
-            if any(e.severity == "error" for e in errors):
-                sys.exit(1)
-        
-        # Show suggestions if requested
-        if suggest or suggestions:
-            if suggestions:
-                get_console().print("[bold blue]💡 Suggestions:[/bold blue]")
-                for suggestion in suggestions:
-                    get_console().print(f"  [blue]{suggestion}[/blue]")
-            
-            if suggest:
-                return
-        
-        # Get next todo ID for the project
-        target_project = parsed.project or project or config.default_project
-        proj, existing_todos = storage.load_project(target_project)
-        
-        if existing_todos:
-            next_id = max(todo.id for todo in existing_todos) + 1
-        else:
-            next_id = 1
-        
-        # Convert ParsedTask to Todo using TaskBuilder
-        builder = TaskBuilder(config)
-        todo = builder.build(parsed, next_id)
-        todo.project = target_project
-        
+
         if dry_run:
+            parsed, _, _ = parse_task_input(
+                input_text,
+                config,
+                project_hint=project or config.default_project,
+            )
+            preview_todo = TaskBuilder(config).build(parsed, 1)
             get_console().print("[bold yellow]🔍 DRY RUN - Would create:[/bold yellow]")
-            get_console().print(f"  {format_todo_for_display(todo)}")
+            get_console().print(f"  {format_todo_for_display(preview_todo, show_id=False)}")
             return
-        
-        # Add the todo
-        existing_todos.append(todo)
-        
-        # Save the project
-        if storage.save_project(proj, existing_todos):
-            get_console().print(f"[green]✅ Added:[/green] {format_todo_for_display(todo)}")
-        else:
-            get_console().print("[red]❌ Failed to save todo[/red]")
-            sys.exit(1)
-            
-    except Exception as e:
+
+        result = add_task_from_input(
+            storage=storage,
+            config=config,
+            input_text=input_text,
+            project=project,
+        )
+        if suggest and result.suggestions:
+            get_console().print("[bold blue]💡 Suggestions:[/bold blue]")
+            for suggestion in result.suggestions:
+                get_console().print(f"  [blue]{suggestion}[/blue]")
+
+        get_console().print(f"[green]✅ Added:[/green] {format_todo_for_display(result.todo)}")
+
+    except (TodoCliError, ParseError) as e:
         get_console().print(f"[red]❌ Error creating todo: {e}[/red]")
         sys.exit(1)
 

--- a/src/todo_cli/config.py
+++ b/src/todo_cli/config.py
@@ -103,6 +103,10 @@ class ConfigModel:
     collab_username: Optional[str] = None
     collab_server_url: str = "http://localhost:8000"
     collab_auto_sync: bool = True
+    
+    # Reliability / diagnostics
+    strict_validation: bool = False
+    log_level: str = "INFO"
 
     def __post_init__(self):
         """Post-initialization setup."""
@@ -177,6 +181,8 @@ class ConfigModel:
             "collab_username": self.collab_username,
             "collab_server_url": self.collab_server_url,
             "collab_auto_sync": self.collab_auto_sync,
+            "strict_validation": self.strict_validation,
+            "log_level": self.log_level,
         }
         if yaml is not None:
             return yaml.dump(data, default_flow_style=False)

--- a/src/todo_cli/core/__init__.py
+++ b/src/todo_cli/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core cross-cutting concerns (errors, logging, etc.)."""

--- a/src/todo_cli/core/errors.py
+++ b/src/todo_cli/core/errors.py
@@ -1,0 +1,21 @@
+"""Centralized application error taxonomy."""
+
+
+class TodoCliError(Exception):
+    """Base error for all Todo CLI domain/application failures."""
+
+
+class ValidationError(TodoCliError):
+    """Raised when input or entity validation fails."""
+
+
+class ConfigurationError(TodoCliError):
+    """Raised when configuration is invalid or unavailable."""
+
+
+class StorageError(TodoCliError):
+    """Raised for persistence and serialization errors."""
+
+
+class ProviderError(TodoCliError):
+    """Raised for external provider/network failures."""

--- a/src/todo_cli/core/logging.py
+++ b/src/todo_cli/core/logging.py
@@ -1,0 +1,12 @@
+"""Shared logging setup helpers."""
+
+import logging
+
+
+def configure_logging(verbose: bool = False) -> None:
+    """Configure root logging level and format once for CLI/API entrypoints."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )

--- a/src/todo_cli/domain/todo.py
+++ b/src/todo_cli/domain/todo.py
@@ -117,8 +117,34 @@ class Todo:
         # Update modified timestamp
         self.modified = now_utc()
         
-        # Temporarily disable validation to isolate parsing issue
-        pass
+        self._normalize_state()
+
+    def _normalize_state(self):
+        """Normalize and enforce cross-field state invariants."""
+        # Keep progress in valid bounds
+        self.progress = max(0.0, min(1.0, float(self.progress)))
+
+        # Completed status and completed flag must remain consistent
+        if self.status == TodoStatus.COMPLETED:
+            self.completed = True
+        elif self.completed and self.status != TodoStatus.COMPLETED:
+            self.status = TodoStatus.COMPLETED
+
+        # Promote fully complete progress to completed state
+        if self.progress >= 1.0 and not self.completed:
+            self.completed = True
+            self.status = TodoStatus.COMPLETED
+
+        # Ensure completed tasks always have completion date and full progress
+        if self.completed:
+            if self.completed_date is None:
+                self.completed_date = now_utc()
+            self.progress = 1.0
+
+        # If status is not completed, avoid stale completion metadata
+        if self.status != TodoStatus.COMPLETED and not self.completed:
+            self.completed_date = None
+            self.completed_by = None
     
     def complete(self, completed_by: Optional[str] = None):
         """Mark the task as completed."""

--- a/src/todo_cli/infrastructure/__init__.py
+++ b/src/todo_cli/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure adapters and persistence utilities."""

--- a/src/todo_cli/infrastructure/storage/__init__.py
+++ b/src/todo_cli/infrastructure/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage infrastructure modules and codecs."""

--- a/src/todo_cli/infrastructure/storage/markdown_task_codec.py
+++ b/src/todo_cli/infrastructure/storage/markdown_task_codec.py
@@ -1,0 +1,23 @@
+"""Markdown codec for Todo lines with inline metadata and ID comments."""
+
+from typing import Optional, Tuple
+
+from ...storage import TodoMarkdownFormat
+from ...domain import Todo
+
+
+def todo_to_markdown(todo: Todo) -> str:
+    """Serialize Todo to markdown task representation."""
+    return TodoMarkdownFormat.to_markdown(todo)
+
+
+def todo_from_markdown(line: str, project: str = "inbox", line_id: Optional[int] = None) -> Optional[Todo]:
+    """Deserialize markdown task line into Todo."""
+    return TodoMarkdownFormat.from_markdown(line, project=project, line_id=line_id)
+
+
+def strip_id_comments(text: str) -> Tuple[Optional[int], str]:
+    """Extract last embedded ID comment and return cleaned text."""
+    from ...storage import extract_last_id_and_strip
+
+    return extract_last_id_and_strip(text)

--- a/src/todo_cli/infrastructure/storage/repository.py
+++ b/src/todo_cli/infrastructure/storage/repository.py
@@ -2,6 +2,7 @@
 
 from typing import List, Tuple
 
+from ...core.errors import StorageError
 from ...domain import Project, Todo
 from ...storage import Storage
 
@@ -16,15 +17,24 @@ class TodoRepository:
         return self.storage.list_projects()
 
     def load_project(self, project_name: str) -> Tuple[Project, List[Todo]]:
-        return self.storage.load_project(project_name)
+        """Load a project and its todos.
+
+        Raises:
+            StorageError: If the project file cannot be read or parsed.
+        """
+        project, todos = self.storage.load_project(project_name)
+        if project is None:
+            raise StorageError(f"Failed to load project '{project_name}'")
+        return project, todos
 
     def save_project(self, project: Project, todos: List[Todo]) -> bool:
         return self.storage.save_project(project, todos)
 
-    def next_todo_id(self, project_name: str) -> int:
+    def next_todo_id(self) -> int:
+        """Return the next globally unique todo ID across all projects."""
         return self.storage.get_next_todo_id()
 
     def add_todo(self, project_name: str, todo: Todo) -> bool:
-        project, todos = self.storage.load_project(project_name)
+        project, todos = self.load_project(project_name)
         todos.append(todo)
         return self.storage.save_project(project, todos)

--- a/src/todo_cli/infrastructure/storage/repository.py
+++ b/src/todo_cli/infrastructure/storage/repository.py
@@ -1,0 +1,31 @@
+"""Repository abstraction over Storage for todo/project persistence."""
+
+from typing import List, Tuple
+
+from ...domain import Project, Todo
+from ...storage import Storage
+
+
+class TodoRepository:
+    """Encapsulates todo persistence operations."""
+
+    def __init__(self, storage: Storage):
+        self.storage = storage
+
+    def list_projects(self) -> List[str]:
+        return self.storage.list_projects()
+
+    def load_project(self, project_name: str) -> Tuple[Project, List[Todo]]:
+        return self.storage.load_project(project_name)
+
+    def save_project(self, project: Project, todos: List[Todo]) -> bool:
+        return self.storage.save_project(project, todos)
+
+    def next_todo_id(self, project_name: str) -> int:
+        _, todos = self.storage.load_project(project_name)
+        return (max(todo.id for todo in todos) + 1) if todos else 1
+
+    def add_todo(self, project_name: str, todo: Todo) -> bool:
+        project, todos = self.storage.load_project(project_name)
+        todos.append(todo)
+        return self.storage.save_project(project, todos)

--- a/src/todo_cli/infrastructure/storage/repository.py
+++ b/src/todo_cli/infrastructure/storage/repository.py
@@ -22,8 +22,7 @@ class TodoRepository:
         return self.storage.save_project(project, todos)
 
     def next_todo_id(self, project_name: str) -> int:
-        _, todos = self.storage.load_project(project_name)
-        return (max(todo.id for todo in todos) + 1) if todos else 1
+        return self.storage.get_next_todo_id()
 
     def add_todo(self, project_name: str, todo: Todo) -> bool:
         project, todos = self.storage.load_project(project_name)

--- a/tests/test_application_task_commands.py
+++ b/tests/test_application_task_commands.py
@@ -1,0 +1,24 @@
+"""Tests for application-layer task command handlers."""
+
+from todo_cli.application.task_commands import add_task_from_input
+from todo_cli.config import ConfigModel
+from todo_cli.storage import Storage
+
+
+def test_add_task_from_input_persists_task(tmp_path):
+    config = ConfigModel(data_dir=str(tmp_path / "todo_data"), backup_dir=str(tmp_path / "todo_backups"))
+    storage = Storage(config)
+
+    result = add_task_from_input(
+        storage=storage,
+        config=config,
+        input_text="Write tests for application layer @dev ~high",
+        project="inbox",
+    )
+
+    assert result.todo.id == 1
+    assert result.todo.text.startswith("Write tests")
+
+    _, todos = storage.load_project("inbox")
+    assert len(todos) == 1
+    assert todos[0].text == result.todo.text

--- a/tests/test_refactor_foundations.py
+++ b/tests/test_refactor_foundations.py
@@ -1,0 +1,36 @@
+"""Tests for refactor foundations (config + application layer)."""
+
+import pytest
+
+from todo_cli.application.task_commands import add_task_from_input
+from todo_cli.config import ConfigModel
+from todo_cli.core.errors import ValidationError
+from todo_cli.storage import Storage
+
+
+def test_config_round_trip_includes_refactor_flags(tmp_path):
+    config = ConfigModel(
+        data_dir=str(tmp_path / "data"),
+        backup_dir=str(tmp_path / "backups"),
+        strict_validation=True,
+        log_level="DEBUG",
+    )
+
+    serialized = config.to_yaml()
+    restored = ConfigModel.from_yaml(serialized)
+
+    assert restored.strict_validation is True
+    assert restored.log_level == "DEBUG"
+
+
+def test_add_task_from_input_raises_validation_error_for_invalid_input(tmp_path):
+    config = ConfigModel(data_dir=str(tmp_path / "data"), backup_dir=str(tmp_path / "backups"))
+    storage = Storage(config)
+
+    with pytest.raises(ValidationError):
+        add_task_from_input(
+            storage=storage,
+            config=config,
+            input_text="Broken priority example ~totallyinvalid",
+            project="inbox",
+        )

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -200,6 +200,7 @@ class TestTodo:
         assert data["tags"] == ["urgent", "work"]
         assert data["assignees"] == ["john", "jane"]
         assert data["status"] == "pending"
+
     def test_todo_post_init_normalizes_completed_status(self):
         """Test post-init consistency between status and completed fields."""
         todo = Todo(id=99, text="Done task", completed=True)

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -200,3 +200,21 @@ class TestTodo:
         assert data["tags"] == ["urgent", "work"]
         assert data["assignees"] == ["john", "jane"]
         assert data["status"] == "pending"
+    def test_todo_post_init_normalizes_completed_status(self):
+        """Test post-init consistency between status and completed fields."""
+        todo = Todo(id=99, text="Done task", completed=True)
+
+        assert todo.status == TodoStatus.COMPLETED
+        assert todo.completed is True
+        assert todo.completed_date is not None
+        assert todo.progress == 1.0
+
+    def test_todo_post_init_clamps_progress(self):
+        """Test post-init clamps invalid progress values."""
+        low = Todo(id=100, text="Low progress", progress=-2)
+        high = Todo(id=101, text="High progress", progress=3)
+
+        assert low.progress == 0.0
+        assert high.progress == 1.0
+        assert high.completed is True
+        assert high.status == TodoStatus.COMPLETED

--- a/tests/test_todo_repository.py
+++ b/tests/test_todo_repository.py
@@ -15,10 +15,16 @@ def test_repository_next_id_and_add(tmp_path):
 
     first = Todo(id=1, text="first", project="inbox")
     assert repo.add_todo("inbox", first)
-    assert repo.next_todo_id("inbox") == 2
 
-    second = Todo(id=2, text="second", project="inbox")
-    assert repo.add_todo("inbox", second)
+    # IDs are allocated globally across all projects, so after adding the
+    # first inbox todo, the next ID for a different project must advance too.
+    assert repo.next_todo_id("work") == 2
 
-    _, todos = repo.load_project("inbox")
-    assert [t.id for t in todos] == [1, 2]
+    second = Todo(id=2, text="second", project="work")
+    assert repo.add_todo("work", second)
+
+    _, inbox_todos = repo.load_project("inbox")
+    assert [t.id for t in inbox_todos] == [1]
+
+    _, work_todos = repo.load_project("work")
+    assert [t.id for t in work_todos] == [2]

--- a/tests/test_todo_repository.py
+++ b/tests/test_todo_repository.py
@@ -1,0 +1,24 @@
+"""Tests for repository abstraction over storage."""
+
+from todo_cli.config import ConfigModel
+from todo_cli.domain import Todo
+from todo_cli.infrastructure.storage.repository import TodoRepository
+from todo_cli.storage import Storage
+
+
+def test_repository_next_id_and_add(tmp_path):
+    config = ConfigModel(data_dir=str(tmp_path / "data"), backup_dir=str(tmp_path / "backups"))
+    storage = Storage(config)
+    repo = TodoRepository(storage)
+
+    assert repo.next_todo_id("inbox") == 1
+
+    first = Todo(id=1, text="first", project="inbox")
+    assert repo.add_todo("inbox", first)
+    assert repo.next_todo_id("inbox") == 2
+
+    second = Todo(id=2, text="second", project="inbox")
+    assert repo.add_todo("inbox", second)
+
+    _, todos = repo.load_project("inbox")
+    assert [t.id for t in todos] == [1, 2]

--- a/tests/test_todo_repository.py
+++ b/tests/test_todo_repository.py
@@ -1,9 +1,11 @@
 """Tests for repository abstraction over storage."""
 
 from todo_cli.config import ConfigModel
+from todo_cli.core.errors import StorageError
 from todo_cli.domain import Todo
 from todo_cli.infrastructure.storage.repository import TodoRepository
 from todo_cli.storage import Storage
+import pytest
 
 
 def test_repository_next_id_and_add(tmp_path):
@@ -11,14 +13,14 @@ def test_repository_next_id_and_add(tmp_path):
     storage = Storage(config)
     repo = TodoRepository(storage)
 
-    assert repo.next_todo_id("inbox") == 1
+    # IDs are allocated globally across all projects.
+    assert repo.next_todo_id() == 1
 
     first = Todo(id=1, text="first", project="inbox")
     assert repo.add_todo("inbox", first)
 
-    # IDs are allocated globally across all projects, so after adding the
-    # first inbox todo, the next ID for a different project must advance too.
-    assert repo.next_todo_id("work") == 2
+    # After adding the first inbox todo, the next global ID must advance.
+    assert repo.next_todo_id() == 2
 
     second = Todo(id=2, text="second", project="work")
     assert repo.add_todo("work", second)
@@ -28,3 +30,19 @@ def test_repository_next_id_and_add(tmp_path):
 
     _, work_todos = repo.load_project("work")
     assert [t.id for t in work_todos] == [2]
+
+
+def test_load_project_raises_storage_error_on_corrupt_file(tmp_path):
+    """load_project must raise StorageError rather than returning None."""
+    config = ConfigModel(data_dir=str(tmp_path / "data"), backup_dir=str(tmp_path / "backups"))
+    storage = Storage(config)
+    repo = TodoRepository(storage)
+
+    # Write a corrupt (non-parseable) markdown file for the project.
+    projects_dir = tmp_path / "data" / "projects"
+    projects_dir.mkdir(parents=True, exist_ok=True)
+    corrupt_file = projects_dir / "corrupt.md"
+    corrupt_file.write_text("<<< this is not valid project markdown >>>")
+
+    with pytest.raises(StorageError):
+        repo.load_project("corrupt")


### PR DESCRIPTION
### Motivation

- Separate concerns by moving command handling out of the CLI into an application layer to make business logic testable and reduce module coupling.
- Introduce a small error taxonomy and logging helpers to standardize error propagation and observability across CLI and services.
- Re-enable and formalize domain invariants for `Todo` to prevent silent data corruption and normalize state on construction.
- Add a repository abstraction and markdown codec placeholders to decouple storage persistence from higher-level use-cases.

### Description

- Added a refactor plan document at `docs/REFACTOR_REVIEW_PLAN.md` describing recommended architectural changes and a phased roadmap. 
- Introduced an application use-case module `src/todo_cli/application/task_commands.py` with `add_task_from_input` that encapsulates parsing, suggestion generation, validation, ID allocation, and persistence via a repository. 
- Refactored the CLI `src/todo_cli/cli/tasks.py` to delegate the `add` flow to the new application function, to support `--dry-run` previews, and to catch unified errors (`TodoCliError`, `ParseError`).
- Added core cross-cutting modules: `src/todo_cli/core/errors.py` for a `TodoCliError` taxonomy and `src/todo_cli/core/logging.py` to configure logging.
- Reinstated and tightened `Todo` post-init validation in `src/todo_cli/domain/todo.py` with `_normalize_state` to clamp `progress`, reconcile `status`/`completed`, and maintain completion metadata.
- Added infrastructure storage scaffolding under `src/todo_cli/infrastructure/storage/` including a Markdown codec and `TodoRepository` to encapsulate `Storage` operations and `next_todo_id` logic.
- Extended `ConfigModel` in `src/todo_cli/config.py` with refactor flags `strict_validation` and `log_level` and included them in serialization.
- Added unit tests: `tests/test_application_task_commands.py`, `tests/test_refactor_foundations.py`, `tests/test_todo_repository.py`, and extended `tests/test_todo.py` to validate the new `Todo` invariants.

### Testing

- Ran the test suite with `pytest`, specifically exercising `tests/test_application_task_commands.py`, `tests/test_refactor_foundations.py`, `tests/test_todo_repo­sitory.py`, and `tests/test_todo.py`.
- All added and existing automated tests passed locally (`pytest` completed without failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60701b9b08332998bde16e125f17b)